### PR TITLE
Plotting options

### DIFF
--- a/stablinrb/plotting.py
+++ b/stablinrb/plotting.py
@@ -65,6 +65,7 @@ def image_mode(
     harm: float,
     filename: str,
     notbare: bool = True,
+    realbare: bool = False,
 ) -> None:
     """Create an image for one mode and save it in a file.
 
@@ -87,14 +88,18 @@ def image_mode(
         lw = 2 * speed / speed.max()
         plt.streamplot(xgr, zgr, u2d, w2d, linewidth=lw, density=0.7)
     # labels etc.
-    if notbare:
-        axis.tick_params(axis="both", which="major", labelsize=FTSZ)
-        axis.set_xlabel(r"$x$", fontsize=FTSZ + 2)
-        axis.set_ylabel(r"$z$", fontsize=FTSZ + 2)
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes("right", size="5%", pad=0.2)
-        cbar = plt.colorbar(surf, cax=cax)
-        cbar.set_label(r"$T$")
+    if realbare:
+        plt.xticks([])
+        plt.yticks([])
+    else:
+        if notbare:
+            axis.tick_params(axis="both", which="major", labelsize=FTSZ)
+            axis.set_xlabel(r"$x$", fontsize=FTSZ + 2)
+            axis.set_ylabel(r"$z$", fontsize=FTSZ + 2)
+            divider = make_axes_locatable(ax)
+            cax = divider.append_axes("right", size="5%", pad=0.2)
+            cbar = plt.colorbar(surf, cax=cax)
+            cbar.set_label(r"$T$")
     if harm > 0.6:
         fig.set_figwidth(9)
         axis.set_aspect("equal")
@@ -228,6 +233,7 @@ def plot_fastest_mode_cart(
     name: Optional[str] = None,
     plot_theory: bool = False,
     notbare: bool = True,
+    realbare: bool = False,
 ) -> None:
     """Plot fastest growing mode for a given harmonic and Ra
 
@@ -309,7 +315,7 @@ def plot_fastest_mode_cart(
     w2d1, w2d2 = np.meshgrid(modx, w_interp)
     w2d = np.real(w2d1 * w2d2)
     filename = "_".join((name, "mode.pdf"))
-    image_mode(xgr, zgr, t2d, u2d, w2d, harm, filename, notbare)
+    image_mode(xgr, zgr, t2d, u2d, w2d, harm, filename, notbare, realbare)
 
 
 def plot_fastest_mode_sph(

--- a/stablinrb/plotting.py
+++ b/stablinrb/plotting.py
@@ -64,6 +64,8 @@ def image_mode(
     w2d: NDArray,
     harm: float,
     filename: str,
+    plot_T: bool = True,
+    plot_stream: bool = True,
     notbare: bool = True,
     realbare: bool = False,
 ) -> None:
@@ -78,15 +80,17 @@ def image_mode(
     axis = fig.add_subplot(111)
     ax = plt.gca()
     # plot temperature
-    surf = plt.pcolormesh(
-        xgr, zgr, t2d, cmap=mypal, rasterized=True, linewidth=0, shading="gouraud"
-    )
+    if plot_T:
+        surf = plt.pcolormesh(
+            xgr, zgr, t2d, cmap=mypal, rasterized=True, linewidth=0, shading="gouraud"
+        )
     plt.axis((xgr.min(), xgr.max(), zgr.min(), zgr.max()))
     # stream function
-    speed = np.sqrt(u2d**2 + w2d**2)
-    if speed.max() > 0:
-        lw = 2 * speed / speed.max()
-        plt.streamplot(xgr, zgr, u2d, w2d, linewidth=lw, density=0.7)
+    if plot_stream:
+        speed = np.sqrt(u2d**2 + w2d**2)
+        if speed.max() > 0:
+            lw = 2 * speed / speed.max()
+            plt.streamplot(xgr, zgr, u2d, w2d, linewidth=lw, density=0.7)
     # labels etc.
     if realbare:
         plt.xticks([])
@@ -232,6 +236,8 @@ def plot_fastest_mode_cart(
     ra_comp: Optional[float] = None,
     name: Optional[str] = None,
     plot_theory: bool = False,
+    plot_T: bool = True,
+    plot_stream: bool = True,
     notbare: bool = True,
     realbare: bool = False,
 ) -> None:
@@ -315,7 +321,7 @@ def plot_fastest_mode_cart(
     w2d1, w2d2 = np.meshgrid(modx, w_interp)
     w2d = np.real(w2d1 * w2d2)
     filename = "_".join((name, "mode.pdf"))
-    image_mode(xgr, zgr, t2d, u2d, w2d, harm, filename, notbare, realbare)
+    image_mode(xgr, zgr, t2d, u2d, w2d, harm, filename, plot_T, plot_stream, notbare, realbare)
 
 
 def plot_fastest_mode_sph(


### PR DESCRIPTION
This is a PR created from #3 to keep the scope of the latter small.

I think the changes proposed are good in term of features, i.e. being able to plot only the temperature field, or have various levels of "verbosity" in annotations.

However, even before this PR, I was already not happy with the state of the plotting module. Its functions have exploded in complexity and numbers of arguments since their creations as our plotting needs evolved. I think this complexity is a symptom that the current code is not designed properly. These functions should be decomposed in smaller objects that represent the "subplots" we're interested in and that can be more easily combined rather than adding even more switches. I've had success using https://github.com/amorison/lazympl in other projects to make composable plots and annotations, I'll give this a go.

I'm keeping this PR open for now as a reminder that we want to implement these functionalities, even if the actual design might end up being different.